### PR TITLE
Remove push triggers from CI workflows for Java and Python

### DIFF
--- a/.github/workflows/Java CI with Gradle.yaml
+++ b/.github/workflows/Java CI with Gradle.yaml
@@ -8,8 +8,6 @@
 name: Java CI with Gradle
 
 on:
-  push:
-    branches: [ "production", "testing" ]
   pull_request:
     branches: [ "production", "testing" ]
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,8 +4,6 @@
 name: Python application
 
 on:
-  push:
-    branches: [ "production", "testing" ]
   pull_request:
     branches: [ "production", "testing" ]
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers for both Java and Python CI pipelines. The main change is that workflows will now only run for pull requests targeting the `production` and `testing` branches, and will no longer trigger on direct pushes to these branches.

Workflow trigger updates:

* [`.github/workflows/Java CI with Gradle.yaml`](diffhunk://#diff-1d3685353c584813feb7a58cb6c5b62acd35df4989ce1cd775628e1af0643788L11-L12): Removed the trigger for pushes to `production` and `testing` branches so that the workflow only runs on pull requests.
* [`.github/workflows/python-app.yml`](diffhunk://#diff-d7b3e1cc0b909c52439e5d8d3f602f70644d0f6b62a54825968d819f7a5bee89L7-L8): Removed the trigger for pushes to `production` and `testing` branches so that the workflow only runs on pull requests.