### PR TITLE
Add Quiz feature with backend integration and frontend components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import RegisterPage from './pages/Auth/RegisterPage'
 import BooksPage from './pages/BooksPage'
 import LoansPage from './pages/LoansPage'
 import AboutPage from './pages/AboutPage'
+import QuizPage from './pages/QuizPage'
 
 function App() {
   const { isAuthenticated } = useAuth();
@@ -18,6 +19,7 @@ function App() {
         <Route path="/books" element={<BooksPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/loans" element={isAuthenticated ? <LoansPage /> : <Navigate to="/login" replace />} />
+        <Route path="/quiz" element={isAuthenticated ? <QuizPage /> : <Navigate to="/login" replace />} />
         <Route path="/login" element={isAuthenticated ? <Navigate to="/" replace /> : <LoginPage />} />
         <Route path="/register" element={isAuthenticated ? <Navigate to="/" replace /> : <RegisterPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/layouts/Layout.jsx
+++ b/frontend/src/layouts/Layout.jsx
@@ -25,6 +25,11 @@ export default function MainLayout() {
                 Loans
               </NavLink>
             )}
+            {isAuthenticated && (
+              <NavLink to="/quiz" className={({ isActive }) => `nav-link ${isActive ? "active" : ""}`}>
+                Quiz
+              </NavLink>
+            )}
             {!isAuthenticated ? (
              <>
                 <NavLink to="/login" className={({ isActive}) => `nav-link ${isActive ? "active" : ""}`}>

--- a/frontend/src/pages/QuizPage.css
+++ b/frontend/src/pages/QuizPage.css
@@ -1,0 +1,360 @@
+.quiz-section {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.quiz-empty,
+.quiz-intro {
+  color: #5b4a3b;
+  margin-top: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ── Setup screen ── */
+.quiz-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.quiz-label {
+  font-weight: 600;
+  color: #2a1f17;
+  font-size: 0.95rem;
+}
+
+.quiz-book-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.quiz-book-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0.65rem 1rem;
+  background: #fbf6ed;
+  border: 1px solid #d8c7ad;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: 0.18s ease;
+  text-align: left;
+}
+
+.quiz-book-btn:hover {
+  border-color: var(--wood, #7a5c3e);
+}
+
+.quiz-book-btn.selected {
+  border-color: var(--wood, #7a5c3e);
+  background: #f0e6d2;
+}
+
+.quiz-book-title {
+  font-weight: 600;
+  color: #2a1f17;
+  font-size: 0.95rem;
+}
+
+.quiz-book-author {
+  color: #5b4a3b;
+  font-size: 0.82rem;
+}
+
+.quiz-num-options {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.quiz-num-btn {
+  width: 48px;
+  height: 40px;
+  border: 1px solid #d8c7ad;
+  border-radius: 8px;
+  background: #fbf6ed;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: 0.18s ease;
+  color: #2a1f17;
+}
+
+.quiz-num-btn:hover {
+  border-color: var(--wood, #7a5c3e);
+}
+
+.quiz-num-btn.selected {
+  background: var(--wood, #7a5c3e);
+  border-color: var(--wood, #7a5c3e);
+  color: #fff7ea;
+  font-weight: 700;
+}
+
+.quiz-start-btn {
+  margin-top: 0.5rem;
+  padding: 0.65rem 1.4rem;
+  background: var(--wood, #7a5c3e);
+  color: #fff7ea;
+  border: none;
+  border-radius: 10px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+  transition: 0.18s ease;
+}
+
+.quiz-start-btn:hover:not(:disabled) {
+  background: #5c4230;
+}
+
+.quiz-start-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.quiz-error {
+  color: #a63232;
+  font-size: 0.88rem;
+  margin: 0;
+}
+
+/* ── Active quiz ── */
+.quiz-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quiz-progress {
+  color: #8a7562;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.quiz-card {
+  background: #fbf6ed;
+  border: 1px solid #d8c7ad;
+  border-radius: 14px;
+  padding: 1.5rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 4px 14px rgba(52, 34, 24, 0.06);
+}
+
+.quiz-question {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #2a1f17;
+  margin: 0 0 1.2rem;
+  line-height: 1.5;
+}
+
+.quiz-options {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quiz-option-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: #fff7ea;
+  border: 1px solid #d8c7ad;
+  border-radius: 9px;
+  font-size: 0.95rem;
+  color: #2a1f17;
+  cursor: pointer;
+  text-align: left;
+  transition: 0.18s ease;
+}
+
+.quiz-option-btn:hover {
+  border-color: var(--wood, #7a5c3e);
+}
+
+.quiz-option-btn.selected {
+  background: #f0e6d2;
+  border-color: var(--wood, #7a5c3e);
+  font-weight: 600;
+}
+
+.quiz-option-letter {
+  font-weight: 700;
+  color: var(--wood, #7a5c3e);
+  min-width: 1.2rem;
+}
+
+.quiz-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.quiz-nav-btn {
+  padding: 0.55rem 1.2rem;
+  border: 1px solid #d8c7ad;
+  border-radius: 9px;
+  background: #fbf6ed;
+  color: #2a1f17;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: 0.18s ease;
+}
+
+.quiz-nav-btn:hover:not(:disabled) {
+  border-color: var(--wood, #7a5c3e);
+}
+
+.quiz-nav-btn.primary {
+  background: var(--wood, #7a5c3e);
+  color: #fff7ea;
+  border-color: var(--wood, #7a5c3e);
+  font-weight: 600;
+}
+
+.quiz-nav-btn.primary:hover:not(:disabled) {
+  background: #5c4230;
+}
+
+.quiz-nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Results screen ── */
+.quiz-results-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.quiz-score {
+  font-size: 1.2rem;
+  font-weight: 700;
+  padding: 0.3rem 0.9rem;
+  border-radius: 20px;
+}
+
+.score-good { background: #d4edda; color: #1a5c2e; }
+.score-ok   { background: #fde8cc; color: #7a4000; }
+.score-bad  { background: #f8d7da; color: #721c24; }
+
+.quiz-result-card {
+  background: #fbf6ed;
+  border: 1px solid #d8c7ad;
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+  margin-bottom: 0.85rem;
+}
+
+.quiz-result-card.correct {
+  border-left: 4px solid #3c9e5f;
+}
+
+.quiz-result-card.incorrect {
+  border-left: 4px solid #c0392b;
+}
+
+.quiz-result-question {
+  font-weight: 600;
+  color: #2a1f17;
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.quiz-result-num {
+  color: #8a7562;
+  margin-right: 0.35rem;
+}
+
+.quiz-result-options {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.quiz-result-options li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 7px;
+  font-size: 0.92rem;
+  color: #2a1f17;
+}
+
+.option-correct {
+  background: #d4edda;
+  color: #1a5c2e;
+  font-weight: 600;
+}
+
+.option-wrong {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.option-tick { font-weight: 700; }
+.option-cross { font-weight: 700; }
+
+.quiz-explanation {
+  font-size: 0.88rem;
+  color: #5b4a3b;
+  margin: 0;
+  font-style: italic;
+  border-top: 1px solid #e8ddd0;
+  padding-top: 0.6rem;
+}
+
+.quiz-results-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-bottom: 2rem;
+}
+
+.quiz-retry-btn,
+.quiz-new-btn {
+  padding: 0.55rem 1.2rem;
+  border-radius: 9px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.18s ease;
+}
+
+.quiz-retry-btn {
+  background: var(--wood, #7a5c3e);
+  color: #fff7ea;
+  border: none;
+}
+
+.quiz-retry-btn:hover {
+  background: #5c4230;
+}
+
+.quiz-new-btn {
+  background: transparent;
+  border: 1px solid #d8c7ad;
+  color: #2a1f17;
+}
+
+.quiz-new-btn:hover {
+  border-color: var(--wood, #7a5c3e);
+}

--- a/frontend/src/pages/QuizPage.jsx
+++ b/frontend/src/pages/QuizPage.jsx
@@ -1,0 +1,242 @@
+import { useState } from "react";
+import { useBooks } from "../context/BookContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
+import "./QuizPage.css";
+
+export default function QuizPage() {
+  const { books } = useBooks();
+  const { authFetch } = useAuth();
+
+  const [selectedCopyId, setSelectedCopyId] = useState(null);
+  const [numQuestions, setNumQuestions] = useState(5);
+  const [quiz, setQuiz] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selectedAnswers, setSelectedAnswers] = useState({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const startQuiz = async () => {
+    if (!selectedCopyId) return;
+    setLoading(true);
+    setError("");
+    setQuiz(null);
+    setSelectedAnswers({});
+    setSubmitted(false);
+    setCurrentIndex(0);
+    try {
+      const res = await authFetch("/api/quiz/generate", {
+        method: "POST",
+        body: JSON.stringify({ bookCopyId: selectedCopyId, numQuestions }),
+      });
+      if (!res.ok) {
+        const msg = res.status === 503
+          ? "Quiz service is not configured. Ask your admin to set ANTHROPIC_API_KEY."
+          : `Failed to generate quiz (${res.status})`;
+        throw new Error(msg);
+      }
+      const data = await res.json();
+      setQuiz(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const selectOption = (questionIndex, optionIndex) => {
+    if (submitted) return;
+    setSelectedAnswers((prev) => ({ ...prev, [questionIndex]: optionIndex }));
+  };
+
+  const submitQuiz = () => {
+    setSubmitted(true);
+    setCurrentIndex(0);
+  };
+
+  const resetQuiz = () => {
+    setQuiz(null);
+    setSelectedAnswers({});
+    setSubmitted(false);
+    setCurrentIndex(0);
+    setError("");
+  };
+
+  const score = submitted
+    ? quiz.questions.filter((q, i) => selectedAnswers[i] === q.correctIndex).length
+    : 0;
+
+  if (books.length === 0) {
+    return (
+      <section>
+        <h1>Book Quiz</h1>
+        <p className="quiz-empty">No books in your library yet. Add some books first!</p>
+      </section>
+    );
+  }
+
+  if (quiz && !submitted) {
+    const question = quiz.questions[currentIndex];
+    const total = quiz.questions.length;
+    const allAnswered = Object.keys(selectedAnswers).length === total;
+
+    return (
+      <section className="quiz-section">
+        <div className="quiz-header">
+          <h1>Quiz: {quiz.bookTitle}</h1>
+          <span className="quiz-progress">{currentIndex + 1} / {total}</span>
+        </div>
+
+        <div className="quiz-card">
+          <p className="quiz-question">{question.question}</p>
+          <ul className="quiz-options">
+            {question.options.map((opt, i) => (
+              <li key={i}>
+                <button
+                  className={`quiz-option-btn${selectedAnswers[currentIndex] === i ? " selected" : ""}`}
+                  onClick={() => selectOption(currentIndex, i)}
+                >
+                  <span className="quiz-option-letter">{String.fromCharCode(65 + i)}</span>
+                  {opt}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="quiz-nav">
+          <button
+            className="quiz-nav-btn"
+            disabled={currentIndex === 0}
+            onClick={() => setCurrentIndex((i) => i - 1)}
+          >
+            Previous
+          </button>
+          {currentIndex < total - 1 ? (
+            <button
+              className="quiz-nav-btn primary"
+              onClick={() => setCurrentIndex((i) => i + 1)}
+            >
+              Next
+            </button>
+          ) : (
+            <button
+              className="quiz-nav-btn primary"
+              disabled={!allAnswered}
+              title={!allAnswered ? "Answer all questions first" : ""}
+              onClick={submitQuiz}
+            >
+              Submit Quiz
+            </button>
+          )}
+        </div>
+      </section>
+    );
+  }
+
+  if (quiz && submitted) {
+    const total = quiz.questions.length;
+    const pct = Math.round((score / total) * 100);
+
+    return (
+      <section className="quiz-section">
+        <div className="quiz-results-header">
+          <h1>Results: {quiz.bookTitle}</h1>
+          <div className={`quiz-score ${pct >= 70 ? "score-good" : pct >= 40 ? "score-ok" : "score-bad"}`}>
+            {score} / {total} &mdash; {pct}%
+          </div>
+        </div>
+
+        {quiz.questions.map((q, i) => {
+          const chosen = selectedAnswers[i];
+          const correct = q.correctIndex;
+          const isRight = chosen === correct;
+          return (
+            <div key={i} className={`quiz-result-card ${isRight ? "correct" : "incorrect"}`}>
+              <p className="quiz-result-question">
+                <span className="quiz-result-num">{i + 1}.</span> {q.question}
+              </p>
+              <ul className="quiz-result-options">
+                {q.options.map((opt, j) => (
+                  <li
+                    key={j}
+                    className={
+                      j === correct ? "option-correct" :
+                      j === chosen && !isRight ? "option-wrong" : ""
+                    }
+                  >
+                    <span className="quiz-option-letter">{String.fromCharCode(65 + j)}</span>
+                    {opt}
+                    {j === correct && <span className="option-tick"> ✓</span>}
+                    {j === chosen && !isRight && <span className="option-cross"> ✗</span>}
+                  </li>
+                ))}
+              </ul>
+              {q.explanation && (
+                <p className="quiz-explanation">{q.explanation}</p>
+              )}
+            </div>
+          );
+        })}
+
+        <div className="quiz-results-actions">
+          <button className="quiz-retry-btn" onClick={() => { setSubmitted(false); setSelectedAnswers({}); setCurrentIndex(0); }}>
+            Retry
+          </button>
+          <button className="quiz-new-btn" onClick={resetQuiz}>
+            New Quiz
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="quiz-section">
+      <h1>Book Quiz</h1>
+      <p className="quiz-intro">Select a book from your library and test your knowledge with an AI-generated quiz.</p>
+
+      <div className="quiz-setup">
+        <label className="quiz-label">Choose a book</label>
+        <div className="quiz-book-list">
+          {books.map((copy) => (
+            <button
+              key={copy.id}
+              className={`quiz-book-btn${selectedCopyId === copy.id ? " selected" : ""}`}
+              onClick={() => setSelectedCopyId(copy.id)}
+            >
+              <span className="quiz-book-title">{copy.book?.title}</span>
+              {copy.book?.authors?.[0] && (
+                <span className="quiz-book-author">{copy.book.authors[0]}</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <label className="quiz-label">Number of questions</label>
+        <div className="quiz-num-options">
+          {[3, 5, 10].map((n) => (
+            <button
+              key={n}
+              className={`quiz-num-btn${numQuestions === n ? " selected" : ""}`}
+              onClick={() => setNumQuestions(n)}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+
+        {error && <p className="quiz-error">{error}</p>}
+
+        <button
+          className="quiz-start-btn"
+          disabled={!selectedCopyId || loading}
+          onClick={startQuiz}
+        >
+          {loading ? "Generating quiz…" : "Start Quiz"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/main/java/app/main/LibraryApp/controller/QuizController.java
+++ b/src/main/java/app/main/LibraryApp/controller/QuizController.java
@@ -1,0 +1,44 @@
+package app.main.LibraryApp.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import app.main.LibraryApp.domain.dto.QuizRequest;
+import app.main.LibraryApp.domain.dto.QuizResponse;
+import app.main.LibraryApp.service.QuizService;
+
+@RestController
+@RequestMapping("/api/quiz")
+public class QuizController {
+
+    private final QuizService quizService;
+
+    public QuizController(QuizService quizService) {
+        this.quizService = quizService;
+    }
+
+    @PostMapping("/generate")
+    public ResponseEntity<QuizResponse> generateQuiz(@RequestBody QuizRequest request) {
+        try {
+            QuizResponse response = quizService.generateQuiz(request, getCurrentUserEmail());
+            return ResponseEntity.ok(response);
+        } catch (RuntimeException e) {
+            if (e.getMessage().equals("Book not found")) {
+                return ResponseEntity.status(404).build();
+            } else if (e.getMessage().equals("Unauthorized")) {
+                return ResponseEntity.status(403).build();
+            } else if (e.getMessage().startsWith("OpenAI API key not configured")) {
+                return ResponseEntity.status(503).build();
+            }
+            return ResponseEntity.status(500).build();
+        }
+    }
+
+    private String getCurrentUserEmail() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
+    }
+}

--- a/src/main/java/app/main/LibraryApp/domain/dto/QuizQuestion.java
+++ b/src/main/java/app/main/LibraryApp/domain/dto/QuizQuestion.java
@@ -1,0 +1,13 @@
+package app.main.LibraryApp.domain.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class QuizQuestion {
+    private String question;
+    private List<String> options;
+    private int correctIndex;
+    private String explanation;
+}

--- a/src/main/java/app/main/LibraryApp/domain/dto/QuizRequest.java
+++ b/src/main/java/app/main/LibraryApp/domain/dto/QuizRequest.java
@@ -1,0 +1,9 @@
+package app.main.LibraryApp.domain.dto;
+
+import lombok.Data;
+
+@Data
+public class QuizRequest {
+    private Long bookCopyId;
+    private int numQuestions = 5;
+}

--- a/src/main/java/app/main/LibraryApp/domain/dto/QuizResponse.java
+++ b/src/main/java/app/main/LibraryApp/domain/dto/QuizResponse.java
@@ -1,0 +1,12 @@
+package app.main.LibraryApp.domain.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class QuizResponse {
+    private String bookTitle;
+    private String bookAuthor;
+    private List<QuizQuestion> questions;
+}

--- a/src/main/java/app/main/LibraryApp/service/QuizService.java
+++ b/src/main/java/app/main/LibraryApp/service/QuizService.java
@@ -1,0 +1,148 @@
+package app.main.LibraryApp.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import app.main.LibraryApp.domain.Book;
+import app.main.LibraryApp.domain.BookCopy;
+import app.main.LibraryApp.domain.dto.QuizQuestion;
+import app.main.LibraryApp.domain.dto.QuizRequest;
+import app.main.LibraryApp.domain.dto.QuizResponse;
+import app.main.LibraryApp.repository.BookCopyRepository;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+@Service
+public class QuizService {
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final String OPENAI_MODEL = "gpt-4o-mini";
+
+    private final BookCopyRepository bookCopyRepository;
+
+    @Value("${openai.api.key:}")
+    private String openaiApiKey;
+
+    public QuizService(BookCopyRepository bookCopyRepository) {
+        this.bookCopyRepository = bookCopyRepository;
+    }
+
+    public QuizResponse generateQuiz(QuizRequest request, String userEmail) {
+        BookCopy copy = bookCopyRepository.findById(request.getBookCopyId())
+                .orElseThrow(() -> new RuntimeException("Book not found"));
+
+        if (!copy.getLibrary().getUser().getEmail().equals(userEmail)) {
+            throw new RuntimeException("Unauthorized");
+        }
+
+        Book book = copy.getBook();
+        int numQuestions = request.getNumQuestions() > 0 ? Math.min(request.getNumQuestions(), 10) : 5;
+
+        List<QuizQuestion> questions = callOpenAiApi(book, numQuestions);
+
+        QuizResponse response = new QuizResponse();
+        response.setBookTitle(book.getTitle());
+        response.setBookAuthor(book.getAuthors() != null && !book.getAuthors().isEmpty()
+                ? book.getAuthors().get(0) : "Unknown");
+        response.setQuestions(questions);
+        return response;
+    }
+
+    private List<QuizQuestion> callOpenAiApi(Book book, int numQuestions) {
+        if (openaiApiKey == null || openaiApiKey.isBlank()) {
+            throw new RuntimeException("OpenAI API key not configured");
+        }
+
+        String authorStr = (book.getAuthors() != null && !book.getAuthors().isEmpty())
+                ? String.join(", ", book.getAuthors()) : "Unknown";
+        String genreStr = book.getGenre() != null ? book.getGenre().name() : "UNKNOWN";
+        int year = book.getPublicationYear() != null ? book.getPublicationYear() : 0;
+        String yearStr = year > 0 ? String.valueOf(year) : "year unknown";
+
+        String promptText = String.format(
+                "You are a literary quiz master. Generate %d multiple-choice quiz questions about the book \"%s\" by %s (%s) in the genre %s.\n\n" +
+                "Each question should test knowledge about the book's plot, themes, characters, or historical/literary context.\n\n" +
+                "Respond with ONLY a valid JSON array (no markdown, no explanation) with this exact structure:\n" +
+                "[\n" +
+                "  {\n" +
+                "    \"question\": \"Question text here?\",\n" +
+                "    \"options\": [\"Option A\", \"Option B\", \"Option C\", \"Option D\"],\n" +
+                "    \"correctIndex\": 0,\n" +
+                "    \"explanation\": \"Brief explanation of why this answer is correct.\"\n" +
+                "  }\n" +
+                "]\n\n" +
+                "Make sure correctIndex is the 0-based index of the correct option in the options array.",
+                numQuestions, book.getTitle(), authorStr, yearStr, genreStr
+        );
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+
+            ObjectNode messageContent = mapper.createObjectNode();
+            messageContent.put("role", "user");
+            messageContent.put("content", promptText);
+
+            ObjectNode requestBody = mapper.createObjectNode();
+            requestBody.put("model", OPENAI_MODEL);
+            requestBody.put("max_tokens", 2048);
+            ArrayNode messages = mapper.createArrayNode();
+            messages.add(messageContent);
+            requestBody.set("messages", messages);
+
+            String requestJson = mapper.writeValueAsString(requestBody);
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(OPENAI_API_URL))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + openaiApiKey)
+                    .POST(HttpRequest.BodyPublishers.ofString(requestJson))
+                    .build();
+
+            HttpResponse<String> httpResponse = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (httpResponse.statusCode() != 200) {
+                throw new RuntimeException("OpenAI API error: " + httpResponse.statusCode() + " " + httpResponse.body());
+            }
+
+            JsonNode responseRoot = mapper.readTree(httpResponse.body());
+            String content = responseRoot.path("choices").path(0).path("message").path("content").textValue();
+
+            // Strip markdown code fences if present
+            String jsonText = content.trim();
+            if (jsonText.startsWith("```")) {
+                jsonText = jsonText.replaceAll("```[a-z]*\\n?", "").replaceAll("```", "").trim();
+            }
+
+            JsonNode questionsArray = mapper.readTree(jsonText);
+            List<QuizQuestion> questions = new ArrayList<>();
+            for (JsonNode q : questionsArray) {
+                QuizQuestion question = new QuizQuestion();
+                question.setQuestion(q.path("question").textValue());
+                question.setCorrectIndex(q.path("correctIndex").intValue());
+                question.setExplanation(q.path("explanation").textValue());
+
+                List<String> options = new ArrayList<>();
+                for (JsonNode opt : q.path("options")) {
+                    options.add(opt.textValue());
+                }
+                question.setOptions(options);
+                questions.add(question);
+            }
+            return questions;
+
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to generate quiz: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,3 +14,6 @@ spring:
 jwt:
   secret: ${JWT_SECRET:dGVzdFNlY3JldEtlrnRoaXNJc0xvbmdFbm91Z2hGb3JUZXN0aW5nUHVycG9zZXM=}
   expiration: ${JWT_EXPIRATION:86400000}
+openai:
+  api:
+    key: ${OPENAI_API_KEY:}


### PR DESCRIPTION
This pull request introduces a new AI-powered quiz feature for books in the library application. The main changes include frontend integration for the quiz page, backend API endpoints and DTOs for quiz generation, and UI enhancements for quiz interaction and results display. The feature is accessible only to authenticated users and allows them to select a book, choose the number of questions, and take a quiz generated by the backend service.

**Frontend integration:**

* Added a new route `/quiz` for authenticated users in `App.jsx`, linking to the `QuizPage` component.
* Included a "Quiz" navigation link in the main layout, visible only when authenticated.
* Implemented the `QuizPage.jsx` component, which handles quiz setup, fetching questions, user answers, scoring, and result display.
* Added a dedicated CSS file `QuizPage.css` for styling the quiz UI, including setup, active quiz, and results screens.

**Backend API and DTOs:**

* Added `QuizController.java` with a `/api/quiz/generate` endpoint to generate quizzes for a selected book copy, handling errors and authentication.
* Introduced DTOs: `QuizRequest.java` for quiz generation requests, `QuizResponse.java` for quiz data returned to the frontend, and `QuizQuestion.java` for individual quiz questions. [[1]](diffhunk://#diff-45dcab9217a38ad7d109500c9cabef5b34ddc96de0720399939d4962d5af47ebR1-R9) [[2]](diffhunk://#diff-d69f408024a660e6472da7daa996d230e7b2590620a85e6b014531e6200c2b4aR1-R12) [[3]](diffhunk://#diff-f9593063ffcbd39b2ef36135f7e9ebe66e075d4dd24c6ed92a9a81df20b8c74bR1-R13)